### PR TITLE
Issue #4 LINE Notify APIによる通知処理実装

### DIFF
--- a/src/infrastructure.ts
+++ b/src/infrastructure.ts
@@ -71,4 +71,45 @@ namespace Infrastructure {
 
   }
 
+  export interface NotifyAPIClient {
+    sendMessage(message: string): boolean;
+  }
+
+  export class LINENotifyAPIClientImpl implements NotifyAPIClient {
+
+    constructor(
+      private readonly accessToken: string
+    ) {}
+
+    public sendMessage(message: string): boolean {
+      const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
+        method: "post",
+        headers: {
+          "Authorization": `Bearer ${this.accessToken}`,
+        },
+        payload: {
+          "message": message,
+        },
+      };
+      const response = UrlFetchApp.fetch("https://notify-api.line.me/api/notify", options);
+      const responseCode = response.getResponseCode();
+      if (responseCode === 200) {
+        return true;
+      } else {
+        console.log(`Failed to notify. Response code: ${responseCode}`);
+        return false;
+      }
+    }
+
+  }
+
+  export class MockNotifyAPIClientImpl implements NotifyAPIClient {
+
+    public sendMessage(message: string): boolean {
+      console.log(`Notify:\n${message}`);
+      return true;
+    }
+
+  }
+
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,12 @@
-function myFunction() {
-  console.log("hello world!");
+function remind(): void {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const scheduleDao = new Infrastructure.ScheduleDaoImpl();
+  const today = new Date();
+  const accessToken = PropertiesService.getScriptProperties().getProperty("LINE_NOTIFY_TOKEN");
+  if (!accessToken) throw new Error("LINE Notify access token is not set.");
+  // const apiClient = new Infrastructure.MockNotifyAPIClientImpl();
+  const apiClient = new Infrastructure.LINENotifyAPIClientImpl(accessToken);
+  const reminderService = new UseCases.ReminderService(ss, scheduleDao, today, apiClient);
+
+  reminderService.remind();
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,11 @@
+function testRemind() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const scheduleDao = new Infrastructure.ScheduleDaoImpl();
+  const mockApiClient = new Infrastructure.MockNotifyAPIClientImpl();
+  for (let dateIncrement=0; dateIncrement<30; dateIncrement++) {
+    const today = new Date(2023, 10-1, 17 + dateIncrement);
+    const reminderService = new UseCases.ReminderService(ss, scheduleDao, today, mockApiClient);
+    console.log(`-----${today.getFullYear()}/${today.getMonth()+1}/${today.getDate()}-----`);
+    reminderService.remind();
+  }
+}

--- a/src/usecases.ts
+++ b/src/usecases.ts
@@ -6,6 +6,7 @@ namespace UseCases {
       private readonly ss: GoogleAppsScript.Spreadsheet.Spreadsheet,
       private readonly scheduleDao: Infrastructure.ScheduleDao,
       private readonly today: Date,
+      private readonly apiClient: Infrastructure.NotifyAPIClient,
     ) {}
 
     public remind(): void {
@@ -27,6 +28,12 @@ namespace UseCases {
         tomorrowPractices.forEach(practice => {
           remindMessage += `\n${practice.getRemindMessage()}`;
         });
+      }
+      
+      if (remindMessage !== "") {
+        this.apiClient.sendMessage(remindMessage);
+      } else {
+        console.log("No practice tomorrow.");
       }
     }
     


### PR DESCRIPTION
### 概要
生成されたリマインドメッセージを実際にLINE Notify APIを利用してグループに送信する処理を実装した。

### 変更内容
- 通知処理のAPIクライアントを実装:  
  インターフェース及びLINE Notify API対応の実装クラス，コンソール出力を行うモッククラスを実装
- ユースケース`RemindService`のAPIクライアント利用部分を実装:  
  リマインドするべき練習がなければAPI自体を叩かず，練習がない旨ログ出力するようにした。また，APIクライアントはDIされることになっている。
- エントリポイント実装:  
  `main.ts`の`remind()`関数を実装。アクセストークンはGASの`PropertiesService`で取得する。
- テスト追加:  
  エントリポイントとほぼ同様にして，手動で結果を確認することを想定したテストを追加した。日付を１日ずつインクリメントしながら，各日付に対して`RemindService.remind()`を実行する。

### その他情報
`RemindService`クラスは，「今日」として扱うべき`today: Date`を内部で生成するのではなく，コンストラクタで受け取ることになっている。そのため，今回追加したテストのように外部で日付を設定して，それぞれの日付を「今日」として扱う，というような柔軟な処理が可能となっている。