### PR TITLE
Issue #6 練習の当日リマインドに対応

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -3,6 +3,7 @@ namespace Models {
   export class Practice {
     private readonly date: Date;
     private readonly time: string;
+    private readonly startTime: Date;
     private readonly court: string;
     private readonly courtName: string;
     private readonly booker: string;
@@ -33,6 +34,20 @@ namespace Models {
 
     public getTimeString(): string {
       return this.time;
+    }
+
+    public getStartTime(): Date {
+      const startTimeInt = parseInt(this.time.split("-")[0]);
+      // 08:00~10:00は間違いなく"8-10"と表記する一方で，16:00~21:00は"16-21"だけでなく"4-9", 18:00~21:00は"18-21"だけでなく"6-9"と表記される可能性がある
+      // また，朝7時以前および夜20時以降に練習がスタートすることはないと仮定する。
+      // そこで，startTimeNumが8以上のときはhoursをそのまま解釈し，startTimeNumが0~7のときにはhoursに12を足して「午後」の時間として解釈する
+      if (startTimeInt <= 7) {
+        return new Date(this.date.getFullYear(), this.date.getMonth(), this.date.getDate(), startTimeInt + 12);
+      } else if (startTimeInt >= 8 && startTimeInt <= 23) {
+        return new Date(this.date.getFullYear(), this.date.getMonth(), this.date.getDate(), startTimeInt);
+      } else {
+        throw new Error(`Failed to parse time string: ${this.time}`);
+      }
     }
 
     public getCourtNameString(): string {

--- a/src/usecases.ts
+++ b/src/usecases.ts
@@ -10,8 +10,6 @@ namespace UseCases {
     ) {}
 
     public remind(): void {
-      // 検索条件である，this.todayの次の日の00:00の時刻を取得
-      const tomorrowTime = new Date(this.today.getFullYear(), this.today.getMonth(), this.today.getDate() + 1).getTime();
       // スケジュール一覧を取得
       const scheduleSheets: GoogleAppsScript.Spreadsheet.Sheet[] = [];
       Sets.Months.forEach(month => {
@@ -20,22 +18,44 @@ namespace UseCases {
           scheduleSheets.push(sheet);
         }
       });
-
-      let remindMessage = "";
+      // this.todayの0:00の時刻を取得
+      const todayTime = new Date(this.today.getFullYear(), this.today.getMonth(), this.today.getDate()).getTime();
+      // 検索条件である，this.todayの次の日の0:00の時刻を取得
+      const tomorrowTime = todayTime + 24*60*60*1000;
+      // 午後4時以降の練習を検索するための必要条件として，todayの16:00の時刻を取得
+      const today4pmTime = new Date(this.today.getFullYear(), this.today.getMonth(), this.today.getDate(), 16).getTime();
+      
+      const todayRemindMessages: string[] = [];
+      const tomorrowRemindMessages: string[] = [];
       for (const sheet of scheduleSheets) {
         const schedule = this.scheduleDao.getSchedule(sheet);
+
+        const todayAfter4pmPractices = schedule.filter(practice => {
+          practice.getDateObj().getTime() === todayTime &&
+          practice.getStartTime().getTime() >= today4pmTime;
+        });
+        todayAfter4pmPractices.forEach(practice => {
+          todayRemindMessages.push(`\n本日の練習の再リマインドです\n${practice.getRemindMessage()}`);
+        });
+
         const tomorrowPractices = schedule.filter(practice => practice.getDateObj().getTime() === tomorrowTime);
         tomorrowPractices.forEach(practice => {
-          remindMessage += `\n${practice.getRemindMessage()}`;
+          tomorrowRemindMessages.push(`\n${practice.getRemindMessage()}`);
         });
       }
       
-      if (remindMessage !== "") {
-        remindMessage += "\n\n試合球・練習球は誰が持っていきますか？";
-        this.apiClient.sendMessage(remindMessage);
-      } else {
+      if (todayRemindMessages.length > 0) {
+        todayRemindMessages.forEach(message => {this.apiClient.sendMessage(message)});
+        this.apiClient.sendMessage("\nボール担当の方よろしくお願いいたします");
+      }
+      if (tomorrowRemindMessages.length > 0) {
+        tomorrowRemindMessages.forEach(message => {this.apiClient.sendMessage(message)});
+        this.apiClient.sendMessage("\n試合球・練習球は誰が持っていきますか？");
+      }
+      if (todayRemindMessages.length === 0 && tomorrowRemindMessages.length === 0) {
         console.log("No practice tomorrow.");
       }
+      
     }
     
   }


### PR DESCRIPTION
### 概要
リマインド発火時刻より後に「当日の練習」があった場合，それもリマインドするように実装を変更した。
> これまでは，8-10の練習も18-21(6-9)の練習も同時にリマインドしていた。  
しかし，8-10は前日のリマインドで十分だとしても，18-21のような午後の練習は(前日のリマインドに加えて)その日の練習開始前に再度リマインドされていればより嬉しいはずである。

### 変更内容
- エンティティ`Practice`に`getStartTime()`メソッドを追加:  
  日付だけでなく時刻に紐付いた処理を行うため。ただし，8-10や12-14のように24時間制で書かれた時刻もあれば，6-9のように12時間制で書かれた時刻もある。それらに対応するための処理も書いてある。
- 午後4時以降の練習は，当日にもリマンドするように`ReminderService.remind()`を変更:  
  これに伴いリマインドメッセージも少し変更した。

### その他情報
今回は，一旦処理を完成させることを重視して実装したが，`Practice.getStartTime()`の内部実装など，少し強引に書かれた部分も多い。そういった部分は今後リファクタリングしていきたい。